### PR TITLE
trojan: harden the checks before first writing

### DIFF
--- a/volundr/common/utils.h
+++ b/volundr/common/utils.h
@@ -27,21 +27,24 @@
     }
 
 
-#define ASSERT_RET_NULL(x,y)    ASSERT_RET(x,y,NULL)
-#define ASSERT_RET_FALSE(x,y)   ASSERT_RET(x,y,false)
-#define ASSERT_NULL(x,y)    ASSERT_(x,y,NULL)
-#define ASSERT_FALSE(x,y)   ASSERT_(x,y,false)
+#define ASSERT_RET_NULL(x,y)        ASSERT_RET(x,y,NULL)
+#define ASSERT_RET_FALSE(x,y)       ASSERT_RET(x,y,false)
+#define ASSERT_RET_VAL(x,y,val)     ASSERT_RET(x,y,val)
+#define ASSERT_NULL(x,y)            ASSERT_(x,y,NULL)
+#define ASSERT_FALSE(x,y)           ASSERT_(x,y,false)
 
 // argument asserts
-#define ASSERT_ARG_RET_NULL(x)  ASSERT_RET_NULL(x,ARG_MSG)
-#define ASSERT_ARG_RET_FALSE(x) ASSERT_RET_FALSE(x,ARG_MSG)
+#define ASSERT_ARG_RET_NULL(x)      ASSERT_RET_NULL(x,ARG_MSG)
+#define ASSERT_ARG_RET_FALSE(x)     ASSERT_RET_FALSE(x,ARG_MSG)
+#define ASSERT_ARG_RET_VAL(x, val)  ASSERT_RET_VAL(x,ARG_MSG, val)
 
 // contract asserts
-#define ASSERT_CON_RET_NULL(x)  ASSERT_RET_NULL(x,CON_MSG)
-#define ASSERT_CON_RET_FALSE(x) ASSERT_RET_FALSE(x,CON_MSG)
+#define ASSERT_CON_RET_NULL(x)      ASSERT_RET_NULL(x,CON_MSG)
+#define ASSERT_CON_RET_FALSE(x)     ASSERT_RET_FALSE(x,CON_MSG)
+#define ASSERT_CON_RET_VAL(x, val)  ASSERT_RET_VAL(x,CON_MSG, val)
 
-#define ASSERT_CON_NULL(x)  ASSERT_NULL(x,CON_MSG)
-#define ASSERT_CON_FALSE(x) ASSERT_FALSE(x,CON_MSG)
+#define ASSERT_CON_NULL(x)          ASSERT_NULL(x,CON_MSG)
+#define ASSERT_CON_FALSE(x)         ASSERT_FALSE(x,CON_MSG)
 
 // smart (O'Rlly??) file opens
 typedef enum { F_RW = 1, F_RO, F_OW } open_mode_t;

--- a/volundr/elf/infect.h
+++ b/volundr/elf/infect.h
@@ -15,7 +15,7 @@ typedef struct infect {
 } infect_t;
 
 
-infect_t *inf_load(elf_t *, FILE *);
+infect_t *inf_load(elf_t *, FILE *, open_mode_t);
 elf_off_t inf_scan_segment(infect_t *);
-bool inf_load_and_patch(infect_t *, open_mode_t, long);
+bool inf_load_and_patch(infect_t *, long);
 #endif

--- a/volundr/examples/example-infect01.c
+++ b/volundr/examples/example-infect01.c
@@ -39,9 +39,9 @@ int main(int argc, char **argv)
 
     elf_t *elfo = elf_parse_file(file, fp, m1);
 
-    infect_t *inf = inf_load(elfo, trojanfp);
+    infect_t *inf = inf_load(elfo, trojanfp, m1);
     if (inf_scan_segment(inf)) {
-        if (inf_load_and_patch(inf, m1, (long)0x1122334455667788) == true)
+        if (inf_load_and_patch(inf, (long)0x1122334455667788) == true)
             printf("Done!\nTry running %s\n", file);
         else
             printf("Failed :(\n");


### PR DESCRIPTION
In the first load make the checks more strict to
avoid writing the target and in effect leaving it partially
written. And no, I will not sync at the end.

Also create new ARG/CON macros so I can return custom values.